### PR TITLE
fix: fetch verification token using email instead of token

### DIFF
--- a/server/actions/tokens.ts
+++ b/server/actions/tokens.ts
@@ -13,7 +13,7 @@ import crypto from "crypto"
 export const getVerificationTokenByEmail = async (email: string) => {
   try {
     const verificationToken = await db.query.emailTokens.findFirst({
-      where: eq(emailTokens.token, email),
+      where: eq(emailTokens.email, email),
     })
     return verificationToken
   } catch (error) {


### PR DESCRIPTION
The getVerificationTokenByEmail function was incorrectly querying emailTokens.token instead of emailTokens.email, causing it to always return null. This fix updates the query to correctly search by emailTokens.email, ensuring the function retrieves the correct verification token associated with a given email.